### PR TITLE
Ensure partial names never contain backslashes

### DIFF
--- a/lib/helpers/read-partials.js
+++ b/lib/helpers/read-partials.js
@@ -35,7 +35,7 @@ function readPartials(relativePath, metalsmith) {
     var partial = path.join(absolutePath, files[i]);
     var contents = fs.readFileSync(partial, 'utf8');
 
-    partials[name] = contents;
+    partials[name.replace(/\\/g, '/')] = contents;
   }
 
   return partials;


### PR DESCRIPTION
The result of path.join is used as the name when registering partials. Whenever the partial is in a subdirectory, this presents a problem if the site is built on Windows as the name will contain a backslash instead of the expected forward slash. This results in handlebars being unable to find the partial. Exactly the same problem and fix as https://github.com/superwolff/metalsmith-layouts/pull/82. The 'should accept a partials option' test already covers this case; without this fax, the test fails on Windows due to not finding the partial.