### PR TITLE
Error: Added filename to render callback.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ function plugin(opts){
 
       render(str, clone, function(err, str){
         if (err) {
-          return done(err);
+          return done(new Error('File: ' + file + ' - ' + err));
         }
 
         data.contents = new Buffer(str);


### PR DESCRIPTION
Added filename to the error returned when there's a problem with `render`. This helps to locate the issue in the file.